### PR TITLE
adding ability to provide custom config (module support)

### DIFF
--- a/environments/development.tfvars
+++ b/environments/development.tfvars
@@ -13,7 +13,7 @@ default_tags = {
 # Snowflake
 snowflake_role    = "SYSADMIN"
 snowflake_account = "aua12673"
-snowflake_user    = "matt@infostrux.com"
+snowflake_user    = "TERRAFORM"
 
 # Configuration
 config_dir = "./config"

--- a/environments/development.tfvars
+++ b/environments/development.tfvars
@@ -13,4 +13,7 @@ default_tags = {
 # Snowflake
 snowflake_role    = "SYSADMIN"
 snowflake_account = "aua12673"
-snowflake_user    = "TERRAFORM"
+snowflake_user    = "matt@infostrux.com"
+
+# Configuration
+config_dir = "./config"

--- a/environments/production.tfvars
+++ b/environments/production.tfvars
@@ -24,3 +24,6 @@ tags = {
 snowflake_role    = "SYSADMIN"
 snowflake_account = "aua12673"
 snowflake_user    = "TERRAFORM"
+
+# Configuration
+config_dir = "./config"

--- a/locals.tf
+++ b/locals.tf
@@ -1,9 +1,9 @@
 locals {
   object_prefix   = length(var.project) > 0 ? join("_", [var.environment, var.project]) : var.environment
   create_tags     = length(var.tags) > 0 ? 1 : 0
-  roles_yml       = yamldecode(file("config/roles.yml"))
-  users_yml       = yamldecode(file("config/users.yml"))
-  permissions_yml = yamldecode(file("config/permissions.yml"))
-  database_yml    = yamldecode(file("config/databases.yml"))
-  warehouse_yml   = yamldecode(file("config/warehouses.yml"))
+  roles_yml       = yamldecode(file("${var.config_dir}/roles.yml"))
+  users_yml       = yamldecode(file("${var.config_dir}/users.yml"))
+  permissions_yml = yamldecode(file("${var.config_dir}/permissions.yml"))
+  database_yml    = yamldecode(file("${var.config_dir}/databases.yml"))
+  warehouse_yml   = yamldecode(file("${var.config_dir}/warehouses.yml"))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,12 @@ variable "tag_admin_role" {
   default     = "TAG_ADMIN"
 }
 
+# Configuration
+variable "config_dir" {
+  type        = string
+  description = "The path to your configuration `.yml` files. (databases.yml, permissions.yml, roles.yml, users.yml, warehouses.yml)"
+}
+
 # Snowflake
 variable "snowflake_role" {
   type        = string


### PR DESCRIPTION
When using the module, the end-user has to provide their config files, which can be taken from this repo. This change gives the end user the ability to pass the path to the config directory.