### PR TITLE
add support for service and legacy_service users

### DIFF
--- a/config/users.yml
+++ b/config/users.yml
@@ -2,9 +2,15 @@ users:
   dbt:
     role: transform
     warehouse: transform
+    type: service
   fivetran:
     role: ingestion
     warehouse: ingestion
+    type: legacy_service
   reporting:
     role: analyst
     warehouse: reporting
+  jsmith:
+    role: developer
+    warehouse: developer
+    type: person

--- a/users.tf
+++ b/users.tf
@@ -1,11 +1,68 @@
 locals {
+  user_type = {
+    person         = "PERSON"
+    service        = "SERVICE"
+    legacy_service = "LEGACY_SERVICE"
+  }
   users = {
-    for user, specs in local.users_yml.users : upper(join("_", [local.object_prefix, user])) => specs
+    for user, specs in local.users_yml.users : upper(join("_", [local.object_prefix, user])) => specs if !contains([local.user_type.service, local.user_type.legacy_service], upper(coalesce(lookup(specs, "type", null), "<EMPTY>")))
+  }
+  service_users = {
+    for user, specs in local.users_yml.users : upper(join("_", [local.object_prefix, user])) => specs if upper(coalesce(lookup(specs, "type", null), "<EMPTY>")) == local.user_type.service
+  }
+  legacy_service_users = {
+    for user, specs in local.users_yml.users : upper(join("_", [local.object_prefix, user])) => specs if upper(coalesce(lookup(specs, "type", null), "<EMPTY>")) == local.user_type.legacy_service
   }
 }
 
 resource "snowflake_user" "user" {
   for_each = local.users
+
+  provider = snowflake.useradmin
+
+  name         = each.key
+  login_name   = each.key
+  display_name = each.key
+  comment      = var.comment
+  disabled     = false
+
+  default_warehouse    = snowflake_warehouse.warehouse[each.value.warehouse].name
+  default_role         = snowflake_account_role.functional_role[each.value.role].name
+  must_change_password = false
+
+  lifecycle {
+    ignore_changes = [
+      password,
+      rsa_public_key,
+      rsa_public_key_2
+    ]
+  }
+}
+
+resource "snowflake_service_user" "user" {
+  for_each = local.service_users
+
+  provider = snowflake.useradmin
+
+  name         = each.key
+  login_name   = each.key
+  display_name = each.key
+  comment      = var.comment
+  disabled     = false
+
+  default_warehouse = snowflake_warehouse.warehouse[each.value.warehouse].name
+  default_role      = snowflake_account_role.functional_role[each.value.role].name
+
+  lifecycle {
+    ignore_changes = [
+      rsa_public_key,
+      rsa_public_key_2
+    ]
+  }
+}
+
+resource "snowflake_legacy_service_user" "user" {
+  for_each = local.legacy_service_users
 
   provider = snowflake.useradmin
 


### PR DESCRIPTION
add support for `service` and `legacy_service` users.

this can be done using the `type` attribute, for example:
```
dbt:
    role: transform
    warehouse: transform
    type: service
```
note that the `type` is case insensitive, so  using `type: service` and `type: SERVICE` is exactly the same.

Unfortunately at the moment [user_type](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/user#user_type-1) property of [snowflake_user](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/user) resource is read-only and cannot be set, therefore setting `type` to `person` is exactly the same as omitting the `type` altogether.
e.g. the following segments are the same:
```
jsmith:
    role: developer
    warehouse: developer
    type: person
```
same as:
```
jsmith:
    role: developer
    warehouse: developer
```

