### PR TITLE
Fix user grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,25 @@ The private key must be created as a GitHub environment secret named `SNOWFLAKE_
 1. Navigate to the `config/users.yml` file
 2. Under the `key:value` mapping `users` you can define the name of the role `key` (terraform will prepend the environment and project)
 3. The `value` under the mapping created on `step 2` can be either the role or the warehouse to assign to the user
-    1. To grant a role to the user add a `key:value` literal with `role: name_of_role`
-    2. To grant access to use a warehouse to the user add a `key:value` literal with `warehouse: name_of_warehouse`
+   * To grant a role to the user add a `key:value` literal with `role: name_of_role`
+   * To grant access to use a warehouse to the user add a `key:value` literal with `warehouse: name_of_warehouse`
+   * To set the user type add a `key:value` literal with `type: type_name`, where `type_name` is one of (`person`, `service`, `legacy_service`). 
+       * When not specified it is the same as setting it to `person` i.e. `type: person`
+       * Unfortunately, at the moment [user_type](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/user#user_type-1) property of [snowflake_user](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/user) resource is read-only and cannot be set, therefore setting `type` to `person` is exactly the same as omitting the `type` altogether.
+```
+users:
+  dbt:
+    role: transform
+    warehouse: transform
+    type: service
+  jsmith:
+    role: developer
+    warehouse: developer
+  jdoe:
+    role: developer
+    warehouse: developer
+    type: person
+```
 
 
 ## Variables

--- a/users.tf
+++ b/users.tf
@@ -4,14 +4,22 @@ locals {
     service        = "SERVICE"
     legacy_service = "LEGACY_SERVICE"
   }
+  all_users = {
+    for user, specs in local.users_yml.users : upper(join("_", [local.object_prefix, user])) => merge(
+      specs,
+      {
+        type = upper(coalesce(lookup(specs, "type", null), "<EMPTY>"))
+      }
+    )
+  }
   users = {
-    for user, specs in local.users_yml.users : upper(join("_", [local.object_prefix, user])) => specs if !contains([local.user_type.service, local.user_type.legacy_service], upper(coalesce(lookup(specs, "type", null), "<EMPTY>")))
+    for user, specs in local.all_users : user => specs if !contains([local.user_type.service, local.user_type.legacy_service], specs.type)
   }
   service_users = {
-    for user, specs in local.users_yml.users : upper(join("_", [local.object_prefix, user])) => specs if upper(coalesce(lookup(specs, "type", null), "<EMPTY>")) == local.user_type.service
+    for user, specs in local.all_users : user => specs if specs.type == local.user_type.service
   }
   legacy_service_users = {
-    for user, specs in local.users_yml.users : upper(join("_", [local.object_prefix, user])) => specs if upper(coalesce(lookup(specs, "type", null), "<EMPTY>")) == local.user_type.legacy_service
+    for user, specs in local.users_yml.users : user => specs if specs.type == local.user_type.legacy_service
   }
 }
 

--- a/users.tf
+++ b/users.tf
@@ -19,7 +19,7 @@ locals {
     for user, specs in local.all_users : user => specs if specs.type == local.user_type.service
   }
   legacy_service_users = {
-    for user, specs in local.users_yml.users : user => specs if specs.type == local.user_type.legacy_service
+    for user, specs in local.all_users : user => specs if specs.type == local.user_type.legacy_service
   }
 }
 


### PR DESCRIPTION
From the latest changes, when adding support for `service` and `legacy_service` users, the grants were only created for regular users and not the for `service` and `legacy_service` users.
This PR fixes this and also documents the `type` attribute in the readme. 