### PR TITLE
Snowflake provider 2.1 update

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     snowflake = {
-      source  = "Snowflake-Labs/snowflake"
-      version = "0.99.0"
+      source  = "snowflakedb/snowflake"
+      version = "~>2.1.0"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.80"
+      version = "~> 5.100"
     }
   }
 }
@@ -17,7 +17,8 @@ provider "snowflake" {
   account_name      = var.snowflake_account
   organization_name = var.snowflake_org
   user              = var.snowflake_user
-  authenticator     = "JWT"
+  authenticator     = "SNOWFLAKE_JWT"
+  warehouse         = "COMPUTE_WH"
 }
 
 provider "snowflake" {
@@ -26,7 +27,8 @@ provider "snowflake" {
   account_name      = var.snowflake_account
   organization_name = var.snowflake_org
   user              = var.snowflake_user
-  authenticator     = "JWT"
+  authenticator     = "SNOWFLAKE_JWT"
+  warehouse         = "COMPUTE_WH"
 }
 
 provider "snowflake" {
@@ -35,7 +37,8 @@ provider "snowflake" {
   account_name      = var.snowflake_account
   organization_name = var.snowflake_org
   user              = var.snowflake_user
-  authenticator     = "JWT"
+  authenticator     = "SNOWFLAKE_JWT"
+  warehouse         = "COMPUTE_WH"
 }
 
 provider "snowflake" {
@@ -44,7 +47,8 @@ provider "snowflake" {
   account_name      = var.snowflake_account
   organization_name = var.snowflake_org
   user              = var.snowflake_user
-  authenticator     = "JWT"
+  authenticator     = "SNOWFLAKE_JWT"
+  warehouse         = "COMPUTE_WH"
 }
 
 provider "aws" {

--- a/tags.tf
+++ b/tags.tf
@@ -56,9 +56,8 @@ resource "snowflake_tag_association" "database_tags" {
 
   depends_on = [snowflake_tag.tag]
 
-  object_identifier {
-    name = each.value.database
-  }
+  object_identifiers = [each.value.database]
+
   object_type = "DATABASE"
   tag_id      = each.value.tag_name
   tag_value   = each.value.tag_value
@@ -71,9 +70,8 @@ resource "snowflake_tag_association" "warehouse_tags" {
 
   depends_on = [snowflake_tag.tag]
 
-  object_identifier {
-    name = each.value.warehouse
-  }
+  object_identifiers = [each.value.warehouse]
+
   object_type = "WAREHOUSE"
   tag_id      = each.value.tag_name
   tag_value   = each.value.tag_value


### PR DESCRIPTION
Update the Snowflake provider to 2.1. Minimal changes required:

- authenticator JWT -> SNOWFLAKE_JWT
- object_identifier -> object_identifiers

Additionally, I added the default COMPUTE_WH that comes with every Snowflake account to the provider so even a completely fresh account will have something to work with to actually create the rest of the infra.